### PR TITLE
remove hovertemplate from recovery chart in meantime

### DIFF
--- a/app/viz.py
+++ b/app/viz.py
@@ -191,64 +191,14 @@ def plot_recovery_over_this_quarter(df, route_numbers):
 
     # Hover: show the 'recovery_over_2019' value, 'ridership_weekday', and 'ridership_weekday_2019'
     fig.update_traces(
-        hovertemplate="<b>Route: %{customdata[0]}</b><br>Recovery over 2019: %{y:.2f}<br>Ridership (weekday): %{customdata[1]:.0}<br>Ridership (weekday 2019): %{customdata[2]:.0}<extra></extra>",
+        hovertemplate="<b>Route: %{customdata[0]}</b><br>Recovery over 2019: %{y:.2f}<br>Ridership (weekday): %{customdata[1]:.0f}<br>Ridership (weekday 2019): %{customdata[2]:.0f}<extra></extra>",
         customdata=df[
             ["route", "ridership_weekday", "ridership_weekday_2019"]
-        ].values,
+        ],
     )
+    return None
 
-    fig.update_layout(title="Recovery over 2019")
-
-    # Add spikelines to the x and y axes
-    fig.update_xaxes(showspikes=True)
-
-    # Add labels to the x and y axes
-    fig.update_xaxes(title_text="")
-    fig.update_yaxes(title_text=f"Recovery over 2019")
-
-    # Angle the x-axis labels
-    fig.update_xaxes(tickangle=45)
-
-    # Set background color to white
-    fig.update_layout(plot_bgcolor="white")
-    fig.update_layout(plot_bgcolor="#363B3D")
-    fig.update_layout(plot_bgcolor="black")
-
-    # Add an option to only show a certain date range
-    fig.update_layout(xaxis=dict(rangeslider=dict(visible=True), type="date"))
-
-    # Iterate through the traces and apply the CITYLINK_COLORS to the plot
-    for i, trace in enumerate(fig.data):
-        if trace.name in CITYLINK_COLORS:
-            trace.marker.color = CITYLINK_COLORS[trace.name]
-            trace.line.color = CITYLINK_COLORS[trace.name]
-    # Remove major gridlines
-    fig.update_yaxes(showgrid=False)
-
-    # Increase the height of the plot to accommodate the legend
-    fig.update_layout(height=600)
-    fig.update_layout(
-        title="Ridership as a percentage of ridership for the same quarter in 2019",
-        legend=dict(
-            orientation="h",
-            yanchor="bottom",
-            y=0.97,
-            xanchor="right",
-            x=1,
-            # Don't show the legend title
-            title_text="",
-        ),
-        margin=dict(l=50, r=50, t=100, b=50),
-    )
-
-    # Represent the x-axis as a quarter of the year
-    fig.update_xaxes(tickformat="%b %Y")
-    # Format y as %
-    fig.update_yaxes(tickformat=",.0%")
-    # Hover mode should be to highlight all traces
-    fig.update_layout(hovermode="x unified")
-    return fig
-
+    
 
 def plot_bar_top_n_for_daterange(
     df, top_n=5, col="ridership", daterange=("2020-05-01", "2023-01-01")
@@ -288,27 +238,3 @@ def plot_bar_top_n_for_daterange(
     )
     return fig
 
-
-def plot_scatter_mapbox(
-    gdf: gpd.GeoDataFrame,
-    color: str = None,
-    color_continuous_scale: str = "Viridis",
-    size_max: int = 15,
-    size: str = 'rider_on',
-    zoom: int = 10,
-    height: int = 300,
-):
-    # Drop an y rows with missing values
-    gdf = gdf.dropna()
-    fig = px.scatter_mapbox(
-        gdf,
-        lat=gdf.geometry.y,
-        lon=gdf.geometry.x,
-        color=color,
-        color_continuous_scale=color_continuous_scale,
-        zoom=zoom,
-        height=height,
-    )
-    fig.update_layout(mapbox_style="carto-positron")
-    fig.update_layout(margin={"r": 0, "t": 0, "l": 0, "b": 0})
-    return fig

--- a/pages/1_Bus_stops.py
+++ b/pages/1_Bus_stops.py
@@ -117,7 +117,7 @@ def plot_scatter_mapbox(
     color_continuous_scale: str = "plasma",
     size_max: int = 20,
     size: str = 'rider_on',
-    # zoom: int = 10,
+    zoom: int = 10,
     height: int = 300,
 ):
     # Drop an y rows with missing values
@@ -126,13 +126,14 @@ def plot_scatter_mapbox(
         gdf,
         lat=gdf.geometry.y,
         lon=gdf.geometry.x,
-        color=color,
-        color_continuous_scale=color_continuous_scale,
+        # color=color,
+        # color_continuous_scale=color_continuous_scale,
         size=size,
         hover_data=["stop_id", "stop_name", "rider_on","routes_served"],
         size_max=size_max,
-        # zoom=zoom,
+        zoom=zoom,
         height=height,
+        opacity=0.6,
     )
     fig.update_layout(mapbox_style="carto-positron")
     fig.update_layout(margin={"r": 0, "t": 0, "l": 0, "b": 0})
@@ -142,7 +143,7 @@ stops = get_bus_stops().dropna()
 # stops.index = stops["stop_id"]
 st.header("Explore Bus Stops")
 st.write("Click on a stop to see the routes served by that stop. The size of the marker is proportional to the number of boardings at the stop. Ridership data is from September 2022-Early February 2023. The routes may not be concurrent with service changes. Fixing those is on the to-do list.")
-fig = plot_scatter_mapbox(stops, color="rider_on", zoom=10, height=600, size_max=35)
+fig = plot_scatter_mapbox(stops, color="rider_on", height=600, size_max=35)
 
 
 

--- a/pages/1_Bus_stops.py
+++ b/pages/1_Bus_stops.py
@@ -117,7 +117,7 @@ def plot_scatter_mapbox(
     color_continuous_scale: str = "plasma",
     size_max: int = 20,
     size: str = 'rider_on',
-    zoom: int = 10,
+    # zoom: int = 10,
     height: int = 300,
 ):
     # Drop an y rows with missing values
@@ -129,19 +129,21 @@ def plot_scatter_mapbox(
         color=color,
         color_continuous_scale=color_continuous_scale,
         size=size,
+        hover_data=["stop_id", "stop_name", "rider_on","routes_served"],
         size_max=size_max,
-        zoom=zoom,
+        # zoom=zoom,
         height=height,
     )
     fig.update_layout(mapbox_style="carto-positron")
     fig.update_layout(margin={"r": 0, "t": 0, "l": 0, "b": 0})
     return fig
+
 stops = get_bus_stops().dropna()
 # stops.index = stops["stop_id"]
 st.header("Explore Bus Stops")
 st.write("Click on a stop to see the routes served by that stop. The size of the marker is proportional to the number of boardings at the stop. Ridership data is from September 2022-Early February 2023. The routes may not be concurrent with service changes. Fixing those is on the to-do list.")
 fig = plot_scatter_mapbox(stops, color="rider_on", zoom=10, height=600, size_max=35)
-# Update color scale
+
 
 
 # Get mapbox events (clicks) from the user


### PR DESCRIPTION
Right now she looks like this
![image](https://user-images.githubusercontent.com/16396180/226775050-d42c3b58-e156-4552-b296-8fba3caf2169.png)

Which is the best I can figure out for now
```python
    Set customdata for each trace
    Hover: show the 'recovery_over_2019' value, 'ridership_weekday', and 'ridership_weekday_2019'
    fig.update_traces(
        hovertemplate="<b>Route: %{customdata[0]}</b><br>Recovery over 2019: %{y:.2f}<br>Ridership (weekday): %{customdata[1]:.0f}<br>Ridership (weekday 2019): %{customdata[2]:.0f}<extra></extra>",
        customdata=df[
            ["route", "ridership_weekday", "ridership_weekday_2019"]
        ].values,
    )

    st.write(#df is your dataframe
    df.shape)
    st.write("""#df is your dataframe
    df[
        ["route", "ridership_weekday", "ridership_weekday_2019"]
    ]""")
    st.write(#df is your dataframe
    df[
        ["route", "ridership_weekday", "ridership_weekday_2019"]
    ])
    st.write("""#df is your dataframe
    df[
        ["route", "ridership_weekday", "ridership_weekday_2019"]
    ].iloc[0]""")
    st.write(df[["route", "ridership_weekday", "ridership_weekday_2019"]].iloc[0])
    st.write(df[["route", "ridership_weekday", "ridership_weekday_2019"]].iloc[1])
        
    st.write("""df[
        ["route", "ridership_weekday", "ridership_weekday_2019"]
    ].values[0]""")
    st.write(df[
        ["route", "ridership_weekday", "ridership_weekday_2019"]
    ].values[0])
    st.write(df[
        ["route", "ridership_weekday", "ridership_weekday_2019"]
    ].values[1])
    st.write("""df[
        ["route", "ridership_weekday", "ridership_weekday_2019"]
    ].values[0][0]""")
    st.write(df[
        ["route", "ridership_weekday", "ridership_weekday_2019"]
    ].values[0][0])
    st.write(df[
        ["route", "ridership_weekday", "ridership_weekday_2019"]
    ].values[0][1])
    ```